### PR TITLE
修复路径遍历

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "A router used for load more routers based on directory structure.",
   "main": "src/index.js",
   "scripts": {
-    "build": "node_modules/.bin/babel src --out-dir src --extensions \".ts\" --source-maps"
+    "build": "babel src --out-dir src --extensions \".ts\" --source-maps"
   },
   "dependencies": {
     "core-js": "^3.9.1",
-    "express": "^4.17.1",
+    "express": "^4.17.2",
     "regenerator-runtime": "^0.13.7"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -179,6 +179,8 @@ export function dynamicRouter(userConfig: Partial<typeof defaultConfig>): Reques
     let autoIndex = true
     let questionMarkIndex = req.url.indexOf("?")
     let originPath = (questionMarkIndex === -1? req.url: req.url.substring(0, questionMarkIndex))
+    // 正规化路径，防止其越过站点根目录
+    originPath = Path.normalize(originPath)
     let currentFindPath = originPath.replace(/\/+$/, '') || '/'
     // 对于获得的形如/aaa/bbb/ccc形式的url，应当依次查找/aaa/bbb/ccc、/aaa/bbb、/aaa、/ 四种listener，
     // 并在调用listener之前从req.url中删除已经匹配到的部分。


### PR DESCRIPTION
## 问题

之前版本的代码没有对URL进行正则化，导致可以用 '..' 访问到任何敏感文件。
复现代码如下。

```js
const {dynamicRouter} = require('../src/index')
const express = require('express')
const app = express()
const config = {
  //---default config---
  //本地路由根目录，相对于package.json，会按照顺序搜索
  realPrefix: ["./static/"],
  //该目录下的不会作为路由文件，但是会被检测热更新
  libPrefix: [],
  //当请求目标为目录时，按照此顺序寻找对应的路由
  autoIndex: ["index", "index.html", "index.js", "README.md", "README.txt"],
  //屏蔽符合以下条件的文件（对路由文件无效），支持文件名通配、正则和自定义函数。参数为本地真实路径
  ignore: [
    '*.ts',
    /\.map$/,
    s => s.endsWith('.json'),
    '/config.*'
  ],
}
app.use(dynamicRouter(config))

app.listen(3000)
```

采用 cURL 发起请求测试：

```bash
$ curl --path-as-is http://127.0.0.1:3000/../../../../../../../../../../../../../../../etc/passwd
```

会输出 `/etc/passwd` 内容

## 修复

增加了 Path normalization，从而解决此问题。修复后上述攻击即失效。
Close #5.